### PR TITLE
Fix bug 10296

### DIFF
--- a/aurora/aurora-war/src/main/java/org/silverpeas/looks/aurora/LookAuroraHelper.java
+++ b/aurora/aurora-war/src/main/java/org/silverpeas/looks/aurora/LookAuroraHelper.java
@@ -71,8 +71,6 @@ public class LookAuroraHelper extends LookSilverpeasV5Helper {
   private static final String DEFAULT_VALUE = "toBeDefined";
   private static final Random RANDOM = new Random();
   private static final String BANNER_ALL_SPACES = "*";
-  private DelegatedNewsService delegatedNewsService;
-  private LocalizationBundle messages;
   private LookSettings settings;
   private List<Domain> directoryDomains = null;
   private List<Group> directoryGroups = null;
@@ -83,21 +81,21 @@ public class LookAuroraHelper extends LookSilverpeasV5Helper {
 
   public static LookHelper newLookHelper(HttpSession session) {
     LookHelper lookHelper = new LookAuroraHelper(session);
+    lookHelper.setMainFrame("/look/jsp/MainFrame.jsp");
     session.setAttribute(LookHelper.SESSION_ATT, lookHelper);
+    return lookHelper;
+  }
+
+  public static LookHelper getLookHelper(final HttpSession session) {
+    final LookHelper lookHelper = LookHelper.getLookHelper(session);
+    if (lookHelper == null) {
+      return newLookHelper(session);
+    }
     return lookHelper;
   }
 
   private LookAuroraHelper(HttpSession session) {
     super(session);
-
-    delegatedNewsService = DelegatedNewsService.get();
-
-    String language = getMainSessionController().getFavoriteLanguage();
-
-    messages =
-        ResourceLocator.getLocalizationBundle("org.silverpeas.looks.aurora.multilang.lookBundle",
-            language);
-
     final WeatherSettings weatherSettings = WeatherSettings.get();
     final String basePath = "org.silverpeas.weather.settings.";
     weatherSettings.setSettingsFilePath(
@@ -313,8 +311,9 @@ public class LookAuroraHelper extends LookSilverpeasV5Helper {
   }
 
   private List<News> getDelegatedNews() {
-    List<News> news = new ArrayList<>();
-    List<DelegatedNews> delegatedNews = delegatedNewsService.getAllValidDelegatedNews();
+    final DelegatedNewsService delegatedNewsService = DelegatedNewsService.get();
+    final List<News> news = new ArrayList<>();
+    final List<DelegatedNews> delegatedNews = delegatedNewsService.getAllValidDelegatedNews();
     for (DelegatedNews delegated : delegatedNews) {
       if (delegated != null && isComponentAvailable(delegated.getInstanceId())) {
         News aNews = new News(delegated.getPublicationDetail());
@@ -502,7 +501,9 @@ public class LookAuroraHelper extends LookSilverpeasV5Helper {
   }
 
   public LocalizationBundle getLocalizedBundle() {
-    return messages;
+    final String language = getMainSessionController().getFavoriteLanguage();
+    return ResourceLocator.getLocalizationBundle("org.silverpeas.looks.aurora.multilang.lookBundle",
+        language);
   }
 
   public LookSettings getLookSettings() {

--- a/aurora/aurora-war/src/main/webapp/look/jsp/DomainsBar.jsp
+++ b/aurora/aurora-war/src/main/webapp/look/jsp/DomainsBar.jsp
@@ -30,6 +30,7 @@
 <%@ page import="org.silverpeas.core.web.look.LookHelper" %>
 <%@ page import="org.silverpeas.core.util.StringUtil" %>
 <%@ page import="org.silverpeas.core.util.URLUtil" %>
+<%@ page import="org.silverpeas.looks.aurora.LookAuroraHelper" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
@@ -50,7 +51,7 @@
 
 <%
 GraphicElementFactory gef = (GraphicElementFactory) session.getAttribute(GraphicElementFactory.GE_FACTORY_SESSION_ATT);
-LookHelper helper = LookHelper.getLookHelper(session);
+LookHelper helper = LookAuroraHelper.getLookHelper(session);
 
 String spaceId    	= request.getParameter("privateDomain");
 String subSpaceId   = request.getParameter("privateSubDomain");

--- a/aurora/aurora-war/src/main/webapp/look/jsp/MainFrame.jsp
+++ b/aurora/aurora-war/src/main/webapp/look/jsp/MainFrame.jsp
@@ -38,7 +38,6 @@ if (m_MainSessionCtrl == null) { %>
   LookHelper helper = LookHelper.getLookHelper(session);
 	if (helper == null) {
 	  helper = LookAuroraHelper.newLookHelper(session);
-	  helper.setMainFrame(thisFrame);
 	  login = true;
 	}
 	

--- a/aurora/aurora-war/src/main/webapp/look/jsp/TopBar.jsp
+++ b/aurora/aurora-war/src/main/webapp/look/jsp/TopBar.jsp
@@ -1,10 +1,11 @@
+<%@ page import="org.silverpeas.looks.aurora.LookAuroraHelper" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
 <%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view"%>
 <%@ taglib uri="http://www.silverpeas.com/tld/silverFunctions" prefix="silfn" %>
 <%@ taglib tagdir="/WEB-INF/tags/silverpeas/util" prefix="viewTags" %>
 
-<c:set var="lookHelper" value="${sessionScope.Silverpeas_LookHelper}" />
+<c:set var="lookHelper" value="<%= LookAuroraHelper.getLookHelper(session) %>"/>
 <c:set var="currentHeading" value="${lookHelper.spaceId}"/>
 <c:set var="mainItems" value="${lookHelper.bannerMainItems}"/>
 <c:set var="apps" value="${lookHelper.applications}"/>

--- a/aurora/aurora-war/src/main/webapp/look/jsp/bodyPartAurora.jsp
+++ b/aurora/aurora-war/src/main/webapp/look/jsp/bodyPartAurora.jsp
@@ -26,13 +26,13 @@
 
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
-<%@ page import="org.silverpeas.core.web.look.LookHelper"%>
+<%@ page import="org.silverpeas.looks.aurora.LookAuroraHelper" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view"%>
 <%@ include file="../../admin/jsp/importFrameSet.jsp" %>
 
-<c:set var="lookHelper" value="<%=LookHelper.getLookHelper(session)%>"/>
+<c:set var="lookHelper" value="<%=LookAuroraHelper.getLookHelper(session)%>"/>
 <c:if test="${lookHelper != null}">
   <jsp:useBean id="lookHelper" type="org.silverpeas.looks.aurora.LookAuroraHelper"/>
   <c:set var="navigationWidth" value="${lookHelper.getSettings('domainsBarFramesetWidth','260')}px"/>

--- a/aurora/aurora-war/src/main/webapp/look/jsp/spaceHomePage.jsp
+++ b/aurora/aurora-war/src/main/webapp/look/jsp/spaceHomePage.jsp
@@ -50,7 +50,7 @@
 <view:timeout/>
 
 <%
-  LookAuroraHelper helper = (LookAuroraHelper) LookHelper.getLookHelper(session);
+  LookAuroraHelper helper = (LookAuroraHelper) LookAuroraHelper.getLookHelper(session);
   AuroraSpaceHomePage homepage = helper.getHomePage(request.getParameter("SpaceId"));
   List<PublicationDetail> publications = homepage.getPublications();
   List<PublicationDetail> news = homepage.getNews();


### PR DESCRIPTION
The cause of the bug can be:
* the LookAuroraHelper object isn't in the opened session,
* the localized bundle in the LookAuroraHelper is null.

For the first point, it is not possible because the LookAuroraHelper is
initialized by the MainFrame.jsp that embodies the layout and the
TopBar.jsp is itself loaded from this layout by the Silverpeas layouting
mechanism.
Nevertheless, in order to circumvent such a problem, in case the
LookAuroraHelper isn't yet initialized in the TopBar.jsp, the LookAuroraHelper
object is now instantiated if not yet by a new method:
LookAuroraHelper#getLookHelper(HttpSession) and this method is invoked in the
different JSP of the Aurora Look instead of the
LookHelper#getLookHelper(HttpSession) method.

For the second point, the localization bundle is initialized as an attribute of
the LookAuroraHelper at its construction. So, null localization bundle isn't
possible. In any way, to fix this problem, the localization bundle is'nt more
set as an attribute of the LookAuroraHelper but it is computed each time it is
asked (and as there is a cache management in ResourceLocator of the different
bundles, it is similar to an attribute set).

My thought about the problem is that it can occurs when a session is
transparently serialized/deserialized by Wildfly. The LookHelper classes aren't
marked as Serializable and they currently cannot be marked as such because they
have non serializable attributes (for example, resource bundles aren't
serializable, Silverpeas services aren't serializable, ...). The correct way
to fix this is to refactor the LookHelper in order either to be serializable or
to be CDI session scoped beans.