### PR TITLE
Feature #12259

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
   }
   agent {
     docker {
-      image 'silverpeas/silverbuild'
+      image 'silverpeas/silverbuild:6.3-it'
       args '-v $HOME/.m2:/home/silverbuild/.m2 -v $HOME/.gitconfig:/home/silverbuild/.gitconfig -v $HOME/.ssh:/home/silverbuild/.ssh -v $HOME/.gnupg:/home/silverbuild/.gnupg'
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,7 @@ pipeline {
     stage('Build') {
       steps {
         script {
+          sh "/opt/wildfly-for-tests/wildfly-*.Final/bin/standalone.sh -c standalone-full.xml &> /dev/null &"
           checkParentPOMVersion(version)
           def silverpeasVersion = getSilverpeasLastBuildVersion()
           boolean coreDependencyExists = existsDependency(version, 'core')
@@ -49,6 +50,7 @@ sed -i -e "s/<components.version>[\\\${}0-9a-zA-Z.-]\\+/<components.version>${si
           sh """
 mvn -U versions:set -DgenerateBackupPoms=false -DnewVersion=${version}
 mvn clean install -Pdeployment -Djava.awt.headless=true -Dcontext=ci
+/opt/wildfly-for-tests/wildfly-*.Final/bin/jboss-cli.sh --connect :shutdown
 """
           deleteLockFile(lockFilePath)
         }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.silverpeas</groupId>
     <artifactId>silverpeas-project</artifactId>
-    <version>1.5-build210429</version>
+    <version>1.5-improve-it</version>
   </parent>
   
   <artifactId>looks</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.silverpeas</groupId>
     <artifactId>silverpeas-project</artifactId>
-    <version>1.5-improve-it</version>
+    <version>1.5-SNAPSHOT</version>
   </parent>
   
   <artifactId>looks</artifactId>


### PR DESCRIPTION
Refactor the way the integration tests are running: instead of starting a Wildfly instance for each test class, it is started before the execution of the whole integration tests of the project. So, Wildfly is set as a remote container for Arquillian.
This requires to set up differently Wildfly. Currently, Wildfly 23.0.0 has been prepared for that and a Docker image dedicated to such builds has been pushed into the hub: silverpeas/silverbuild:6.3-it.

Because Silverpeas is now based upon JEE 8 and this specification supports Java 8, changes have occurred to remove some circumvention of the previous limitations of JEE with Java 8. Some integration tests have be rehandled in order to run within a single Wildfly instance shared by all the others integration tests.

This PR depends on the PRs:
- https://github.com/Silverpeas/silverpeas-dependencies-bom/pull/18
- https://github.com/Silverpeas/silverpeas-test-dependencies-bom/pull/5
- https://github.com/Silverpeas/Silverpeas-Project/pull/6
- https://github.com/Silverpeas/Silverpeas-Core/pull/1131
- https://github.com/Silverpeas/Silverpeas-Components/pull/729