### PR TITLE
Bug #12805 for 6.3

### DIFF
--- a/aurora/aurora-war/src/main/java/org/silverpeas/looks/aurora/Space.java
+++ b/aurora/aurora-war/src/main/java/org/silverpeas/looks/aurora/Space.java
@@ -26,7 +26,7 @@ public class Space {
 
   public String getDescription() {
     return WebEncodeHelper
-        .convertWhiteSpacesForHTMLDisplay(Encode.forHtml(spaceInst.getDescription(userLanguage)));
+        .convertBlanksForHtml(Encode.forHtml(spaceInst.getDescription(userLanguage)));
   }
 
   public void setIntro(String intro) {


### PR DESCRIPTION
Take into account the renaming of WebEncodeHelper#convertWhiteSpacesForHTMLDisplay
to WebEncodeHelper#convertBlanksForHtml

Don't forget to take into account also the PRs:
https://github.com/Silverpeas/Silverpeas-Core/pull/1197
https://github.com/Silverpeas/Silverpeas-Components/pull/773