### PR TITLE
Fix bug #14406 - Add missing translates to home space form

### DIFF
--- a/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/data.xml
+++ b/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/data.xml
@@ -11,10 +11,14 @@
             <labelName>Administrateur(s)</labelName>
             <language>fr</language>
         </label>
-        <parameter>
-            <name>cols</name>
-            <value lang="fr">2</value>
-        </parameter>
+        <label>
+            <labelName>Display administrator(s)</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Display administrator(s)</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">1##0</value>
@@ -22,6 +26,14 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
+        </parameter>
+        <parameter>
+            <name>cols</name>
+            <value lang="fr">2</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -39,6 +51,14 @@
             <labelName>Sous espace(s)</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Display subspaces navigation</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>Display subspaces navigation</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -50,6 +70,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -67,6 +91,14 @@
             <labelName>Application(s)</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Display space applications</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>Display space applications</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -78,6 +110,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -95,6 +131,14 @@
             <labelName>Afficher</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Display the news</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>Display the news</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">1##0</value>
@@ -102,6 +146,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <parameter>
             <name>cols</name>
@@ -123,6 +171,14 @@
             <labelName>Emplacement</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Location of the news</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>Location of the news</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">main##right</value>
@@ -130,6 +186,14 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Zone principale##Colonne de droite</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Main##Right side</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Main##Right side</value>
         </parameter>
         <parameter>
             <name>cols</name>
@@ -155,6 +219,14 @@
             <labelName>Présentation</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>News presentation</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>News presentation</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -166,6 +238,14 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Liste##Carrousel</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">List##Carrousel</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">List##Carrousel</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -186,6 +266,14 @@
         <label>
             <labelName>Nombre d'actualité</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>How many news ?</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>How many news ?</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>maxLength</name>
@@ -211,6 +299,14 @@
             <labelName>Prendre en compte les sous-espaces</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>News from subspaces too</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>News from subspaces too</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -222,6 +318,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -243,6 +343,14 @@
             <labelName>Importantes seulement</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Important news only</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Important news only</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -254,6 +362,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -276,8 +388,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Events</labelName>
+            <labelName>Display events</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Display events</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>cols</name>
@@ -290,6 +406,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -308,8 +428,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Medias</labelName>
+            <labelName>Display media</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Display media</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>cols</name>
@@ -322,6 +446,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -340,8 +468,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Taxonomy</labelName>
+            <labelName>Search zone with taxonomy</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Search zone with taxonomy</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>keys</name>
@@ -350,6 +482,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui, sur la plateforme entière##Oui, sur l'espace courant##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes, about the entire platform##Yes, only on this subspace##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -366,6 +502,14 @@
         <label>
             <labelName>Nombre de dernières publications</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Lastest Publications, how many ?</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Lastest Publications, how many ?</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>maxLength</name>
@@ -390,6 +534,14 @@
         <label>
             <labelName>Introduction</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Preface</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Introduction</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -420,8 +572,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Picture</labelName>
+            <labelName>First Picture on the main container</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>First Picture on the main container</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -451,6 +607,10 @@
             <labelName>Shortcut #1 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #1 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -470,6 +630,10 @@
         <label>
             <labelName>Shortcut #1 - Label</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #1 - Label</labelName>
+            <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -491,6 +655,10 @@
             <labelName>Shortcut #1 - Icon</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #1 - Icon</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>galleries</name>
             <value lang="fr">true</value>
@@ -511,6 +679,14 @@
             <labelName>Raccourci #1 - Cible</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Shortcut #1 - Target</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #1 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -518,6 +694,14 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -539,6 +723,10 @@
             <labelName>Shortcut #2 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #2 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -559,6 +747,10 @@
             <labelName>Shortcut #2 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #2 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -578,6 +770,10 @@
         <label>
             <labelName>Shortcut #2 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #2 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -603,6 +799,10 @@
             <labelName>Shortcut #2 - Target</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #2 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -610,6 +810,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -631,6 +835,10 @@
             <labelName>Shortcut #3 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #3 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -651,6 +859,10 @@
             <labelName>Shortcut #3 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #3 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -670,6 +882,10 @@
         <label>
             <labelName>Shortcut #3 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #3 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -695,6 +911,10 @@
             <labelName>Shortcut #3 - Target</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #3 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -702,6 +922,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -723,6 +947,10 @@
             <labelName>Shortcut #4 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #4 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -743,6 +971,10 @@
             <labelName>Shortcut #4 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #4 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -762,6 +994,10 @@
         <label>
             <labelName>Shortcut #4 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #4 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -787,6 +1023,10 @@
             <labelName>Shortcut #4 - Target</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #4 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -794,6 +1034,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -815,6 +1059,10 @@
             <labelName>Shortcut #5 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #5 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -835,6 +1083,10 @@
             <labelName>Shortcut #5 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #5 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -854,6 +1106,10 @@
         <label>
             <labelName>Shortcut #5 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #5 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -879,6 +1135,10 @@
             <labelName>Shortcut #5 - Target</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #5 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -886,6 +1146,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -907,6 +1171,10 @@
             <labelName>Shortcut #6 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #6 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -927,6 +1195,10 @@
             <labelName>Shortcut #6 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #6 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -946,6 +1218,10 @@
         <label>
             <labelName>Shortcut #6 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #6 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -971,6 +1247,10 @@
             <labelName>Shortcut #6 - Target</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #6 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -978,6 +1258,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -999,6 +1283,10 @@
             <labelName>Users</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Users</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -1019,6 +1307,10 @@
             <labelName>Users - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Users - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -1036,8 +1328,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Second picture</labelName>
+            <labelName>Second picture - Right container</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Second picture - Right container</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -1064,8 +1360,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Second picture - Lien</labelName>
+            <labelName>Second picture - Link url</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Second picture - Link url</labelName>
+            <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1084,8 +1384,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>New users</labelName>
+            <labelName>Display new users</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Display new users</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>cols</name>
@@ -1098,6 +1402,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1112,8 +1420,16 @@
         <isDisabled>false</isDisabled>
         <isHidden>false</isHidden>
         <label>
-            <labelName>Titre</labelName>
+            <labelName>Titre de la zone libre</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Free zone Title</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Free zone Title</labelName>
+            <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1130,6 +1446,14 @@
         <label>
             <labelName>Contenu</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Free Content</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Free Content</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -1155,6 +1479,14 @@
             <labelName>Titre</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Right free zone title</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Right free zone title</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -1170,6 +1502,14 @@
         <label>
             <labelName>Contenu</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Right free zone content</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Right free zone content</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>

--- a/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/data.xml
+++ b/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/data.xml
@@ -16,7 +16,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Display administrator(s)</labelName>
+            <labelName>Administrator(en) anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -30,6 +30,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Yes##No</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
         </parameter>
         <parameter>
             <name>cols</name>
@@ -56,7 +60,7 @@
             <language>en</language>
         </label>
          <label>
-            <labelName>Display subspaces navigation</labelName>
+            <labelName>Unterraumnavigation anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -100,7 +104,7 @@
             <language>en</language>
         </label>
          <label>
-            <labelName>Display space applications</labelName>
+            <labelName>Raumanwendungen anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -144,7 +148,7 @@
             <language>en</language>
         </label>
          <label>
-            <labelName>Display the news</labelName>
+            <labelName>Zeigen Sie die Nachrichten an</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -188,7 +192,7 @@
             <language>en</language>
         </label>
          <label>
-            <labelName>Location of the news</labelName>
+            <labelName>Ort der Nachrichten</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -205,7 +209,7 @@
         </parameter>
         <parameter>
             <name>values</name>
-            <value lang="de">Main##Right side</value>
+            <value lang="de">Hauptseite##Rechte Seite</value>
         </parameter>
         <parameter>
             <name>cols</name>
@@ -316,7 +320,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>News from subspaces too</labelName>
+            <labelName>Neuigkeiten auch aus Unterräumen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -364,7 +368,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Important news only</labelName>
+            <labelName>Nur wichtige Neuigkeiten</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -412,7 +416,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Display events</labelName>
+            <labelName>Ereignisse anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -456,7 +460,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Display media</labelName>
+            <labelName>Medien anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -500,7 +504,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Search zone with taxonomy</labelName>
+            <labelName>Suchzone mit Taxonomie</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -540,7 +544,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Lastest Publications, how many ?</labelName>
+            <labelName>Letzte Veröffentlichungen, wie viele?</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -572,7 +576,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Introduction</labelName>
+            <labelName>Vorwort</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -608,7 +612,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>First Picture on the main container</labelName>
+            <labelName>Erstes Bild auf dem Hauptcontainer</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -640,7 +644,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #1 - URL</labelName>
+            <labelName>Abkürzung #1 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -664,7 +668,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #1 - Label</labelName>
+            <labelName>Abkürzung #1 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -688,7 +692,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #1 - Icon</labelName>
+            <labelName>Abkürzung #1 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -716,7 +720,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #1 - Target</labelName>
+            <labelName>Abkürzung #1 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -756,7 +760,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #2 - URL</labelName>
+            <labelName>Abkürzung #2 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -780,7 +784,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #2 - Label</labelName>
+            <labelName>Abkürzung #2 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -804,7 +808,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #2 - Icon</labelName>
+            <labelName>Abkürzung #2 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -832,7 +836,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #2 - Target</labelName>
+            <labelName>Abkürzung #2 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -872,7 +876,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #3 - URL</labelName>
+            <labelName>Abkürzung #3 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -896,7 +900,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #3 - Label</labelName>
+            <labelName>Abkürzung #3 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -920,7 +924,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #3 - Icon</labelName>
+            <labelName>Abkürzung #3 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -948,7 +952,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #3 - Target</labelName>
+            <labelName>Abkürzung #3 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -988,7 +992,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - URL</labelName>
+            <labelName>Abkürzung #4 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1012,7 +1016,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - Label</labelName>
+            <labelName>Abkürzung #4 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1036,7 +1040,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - Icon</labelName>
+            <labelName>Abkürzung #4 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1064,7 +1068,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - Target</labelName>
+            <labelName>Abkürzung #4 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1104,7 +1108,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #5 - URL</labelName>
+            <labelName>Abkürzung #5 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1128,7 +1132,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #5 - Label</labelName>
+            <labelName>Abkürzung #5 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1152,7 +1156,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #5 - Icon</labelName>
+            <labelName>Abkürzung #5 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1180,7 +1184,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #5 - Target</labelName>
+            <labelName>Abkürzung #5 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1220,7 +1224,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #6 - URL</labelName>
+            <labelName>Abkürzung #6 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1244,7 +1248,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #6 - Label</labelName>
+            <labelName>Abkürzung #6 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1268,7 +1272,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #6 - Icon</labelName>
+            <labelName>Abkürzung #6 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1296,7 +1300,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #6 - Target</labelName>
+            <labelName>Abkürzung #6 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1360,7 +1364,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Users - Label</labelName>
+            <labelName>Benutzer - Bezeichnung</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1384,7 +1388,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Second picture - Right container</labelName>
+            <labelName>Zweites Bild - Rechter Container</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1416,7 +1420,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Second picture - Link url</labelName>
+            <labelName>Zweites Bild - Link-URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1440,7 +1444,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Display new users</labelName>
+            <labelName>Neue Benutzer anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1484,7 +1488,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Free zone Title</labelName>
+            <labelName>Freier Zonentitel</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1508,7 +1512,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Free Content</labelName>
+            <labelName>Kostenlose Inhalte</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1540,7 +1544,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Right free zone title</labelName>
+            <labelName>Rechter Freizonentitel</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1564,7 +1568,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Right free zone content</labelName>
+            <labelName>Rechte Freizoneninhalte</labelName>
             <language>de</language>
         </label>
         <parameter>

--- a/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/data.xml
+++ b/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/data.xml
@@ -75,6 +75,10 @@
             <name>values</name>
             <value lang="en">Yes##No</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -115,6 +119,10 @@
             <name>values</name>
             <value lang="en">Yes##No</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -150,6 +158,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Yes##No</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
         </parameter>
         <parameter>
             <name>cols</name>
@@ -241,11 +253,11 @@
         </parameter>
         <parameter>
             <name>values</name>
-            <value lang="en">List##Carrousel</value>
+            <value lang="en">List##Carousel</value>
         </parameter>
         <parameter>
             <name>values</name>
-            <value lang="de">List##Carrousel</value>
+            <value lang="de">Liste##Karussell</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -268,11 +280,11 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>How many news ?</labelName>
+            <labelName>Number of news</labelName>
             <language>en</language>
         </label>
         <label>
-            <labelName>How many news ?</labelName>
+            <labelName>Anzahl der Nachrichten</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -324,6 +336,10 @@
             <value lang="en">Yes##No</value>
         </parameter>
         <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
+        <parameter>
             <name>default</name>
             <value lang="fr">1</value>
         </parameter>
@@ -366,6 +382,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Yes##No</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -411,6 +431,10 @@
             <name>values</name>
             <value lang="en">Yes##No</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -451,6 +475,10 @@
             <name>values</name>
             <value lang="en">Yes##No</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -486,6 +514,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Yes, about the entire platform##Yes, only on this subspace##No</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja, über die gesamte Plattform##Ja, nur auf diesem Unterraum##Nein</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -701,7 +733,7 @@
         </parameter>
         <parameter>
             <name>values</name>
-            <value lang="de">Open in a new tab</value>
+            <value lang="de">In einem neuen Tab öffnen</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -815,6 +847,10 @@
             <name>values</name>
             <value lang="en">Open in a new tab</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">In einem neuen Tab öffnen</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -926,6 +962,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Open in a new tab</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">In einem neuen Tab öffnen</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1039,6 +1079,10 @@
             <name>values</name>
             <value lang="en">Open in a new tab</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">In einem neuen Tab öffnen</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -1151,6 +1195,10 @@
             <name>values</name>
             <value lang="en">Open in a new tab</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">In einem neuen Tab öffnen</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -1262,6 +1310,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Open in a new tab</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">In einem neuen Tab öffnen</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1406,6 +1458,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Yes##No</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>

--- a/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/searchresult.xml
+++ b/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/searchresult.xml
@@ -11,10 +11,14 @@
             <labelName>Administrateur(s)</labelName>
             <language>fr</language>
         </label>
-        <parameter>
-            <name>cols</name>
-            <value lang="fr">2</value>
-        </parameter>
+        <label>
+            <labelName>Display administrator(s)</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Display administrator(s)</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">1##0</value>
@@ -22,6 +26,14 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
+        </parameter>
+        <parameter>
+            <name>cols</name>
+            <value lang="fr">2</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -39,6 +51,14 @@
             <labelName>Sous espace(s)</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Display subspaces navigation</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>Display subspaces navigation</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -50,6 +70,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -67,6 +91,14 @@
             <labelName>Application(s)</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Display space applications</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>Display space applications</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -78,6 +110,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -95,6 +131,14 @@
             <labelName>Afficher</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Display the news</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>Display the news</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">1##0</value>
@@ -102,6 +146,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <parameter>
             <name>cols</name>
@@ -123,6 +171,14 @@
             <labelName>Emplacement</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Location of the news</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>Location of the news</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">main##right</value>
@@ -130,6 +186,14 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Zone principale##Colonne de droite</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Main##Right side</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Main##Right side</value>
         </parameter>
         <parameter>
             <name>cols</name>
@@ -155,6 +219,14 @@
             <labelName>Présentation</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>News presentation</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>News presentation</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -166,6 +238,14 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Liste##Carrousel</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">List##Carrousel</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">List##Carrousel</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -186,6 +266,14 @@
         <label>
             <labelName>Nombre d'actualité</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>How many news ?</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>How many news ?</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>maxLength</name>
@@ -211,6 +299,14 @@
             <labelName>Prendre en compte les sous-espaces</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>News from subspaces too</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>News from subspaces too</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -222,6 +318,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -243,6 +343,14 @@
             <labelName>Importantes seulement</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Important news only</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Important news only</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -254,6 +362,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -276,8 +388,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Events</labelName>
+            <labelName>Display events</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Display events</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>cols</name>
@@ -290,6 +406,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -308,8 +428,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Medias</labelName>
+            <labelName>Display media</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Display media</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>cols</name>
@@ -322,6 +446,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -340,8 +468,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Taxonomy</labelName>
+            <labelName>Search zone with taxonomy</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Search zone with taxonomy</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>keys</name>
@@ -350,6 +482,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui, sur la plateforme entière##Oui, sur l'espace courant##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes, about the entire platform##Yes, only on this subspace##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -366,6 +502,14 @@
         <label>
             <labelName>Nombre de dernières publications</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Lastest Publications, how many ?</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Lastest Publications, how many ?</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>maxLength</name>
@@ -390,6 +534,14 @@
         <label>
             <labelName>Introduction</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Preface</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Introduction</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -420,8 +572,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Picture</labelName>
+            <labelName>First Picture on the main container</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>First Picture on the main container</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -451,6 +607,10 @@
             <labelName>Shortcut #1 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #1 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -470,6 +630,10 @@
         <label>
             <labelName>Shortcut #1 - Label</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #1 - Label</labelName>
+            <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -491,6 +655,10 @@
             <labelName>Shortcut #1 - Icon</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #1 - Icon</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>galleries</name>
             <value lang="fr">true</value>
@@ -511,6 +679,14 @@
             <labelName>Raccourci #1 - Cible</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Shortcut #1 - Target</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #1 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -518,6 +694,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -539,6 +719,10 @@
             <labelName>Shortcut #2 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #2 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -559,6 +743,10 @@
             <labelName>Shortcut #2 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #2 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -578,6 +766,10 @@
         <label>
             <labelName>Shortcut #2 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #2 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -603,6 +795,10 @@
             <labelName>Shortcut #2 - Target</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #2 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -610,6 +806,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -631,6 +831,10 @@
             <labelName>Shortcut #3 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #3 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -651,6 +855,10 @@
             <labelName>Shortcut #3 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #3 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -670,6 +878,10 @@
         <label>
             <labelName>Shortcut #3 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #3 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -695,6 +907,10 @@
             <labelName>Shortcut #3 - Target</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #3 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -702,6 +918,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -723,6 +943,10 @@
             <labelName>Shortcut #4 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #4 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -740,8 +964,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - Label</labelName>
+            <labelName>Shortcut #4 - URL</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #4 - URL</labelName>
+            <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -762,6 +990,10 @@
         <label>
             <labelName>Shortcut #4 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #4 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -784,8 +1016,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - Target</labelName>
+            <labelName>Shortcut #4 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #4 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>keys</name>
@@ -794,6 +1030,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="eb">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -815,6 +1055,10 @@
             <labelName>Shortcut #5 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #5 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -835,6 +1079,10 @@
             <labelName>Shortcut #5 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #5 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -854,6 +1102,10 @@
         <label>
             <labelName>Shortcut #5 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #5 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -887,6 +1139,10 @@
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -906,6 +1162,10 @@
         <label>
             <labelName>Shortcut #6 - URL</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #6 - URL</labelName>
+            <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -927,6 +1187,10 @@
             <labelName>Shortcut #6 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #6 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -946,6 +1210,10 @@
         <label>
             <labelName>Shortcut #6 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #6 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -971,6 +1239,10 @@
             <labelName>Shortcut #6 - Target</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #6 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -978,6 +1250,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -999,6 +1275,10 @@
             <labelName>Users</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Users</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -1019,6 +1299,10 @@
             <labelName>Users - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Users - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -1036,8 +1320,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Second picture</labelName>
+            <labelName>Second picture - Right container</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Second picture - Right container</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -1064,8 +1352,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Second picture - Lien</labelName>
+            <labelName>Second picture - Link url</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Second picture - Link url</labelName>
+            <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1084,8 +1376,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>New users</labelName>
+            <labelName>Display new users</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Display new users</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>cols</name>
@@ -1098,6 +1394,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1112,8 +1412,16 @@
         <isDisabled>false</isDisabled>
         <isHidden>false</isHidden>
         <label>
-            <labelName>Titre</labelName>
+            <labelName>Titre de la zone libre</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Free zone Title</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Free zone Title</labelName>
+            <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1130,6 +1438,14 @@
         <label>
             <labelName>Contenu</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Free Content</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Free Content</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -1155,6 +1471,14 @@
             <labelName>Titre</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Right free zone title</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Right free zone title</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -1170,6 +1494,14 @@
         <label>
             <labelName>Contenu</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Right free zone content</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Right free zone content</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>

--- a/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/searchresult.xml
+++ b/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/searchresult.xml
@@ -32,6 +32,10 @@
             <value lang="en">Yes##No</value>
         </parameter>
         <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
+        <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
         </parameter>
@@ -75,6 +79,10 @@
             <name>values</name>
             <value lang="en">Yes##No</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -115,6 +123,10 @@
             <name>values</name>
             <value lang="en">Yes##No</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -150,6 +162,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Yes##No</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
         </parameter>
         <parameter>
             <name>cols</name>
@@ -241,11 +257,11 @@
         </parameter>
         <parameter>
             <name>values</name>
-            <value lang="en">List##Carrousel</value>
+            <value lang="en">List##Carousel</value>
         </parameter>
         <parameter>
             <name>values</name>
-            <value lang="de">List##Carrousel</value>
+            <value lang="de">Liste##Karussell</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -268,11 +284,11 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>How many news ?</labelName>
+            <labelName>Number of news</labelName>
             <language>en</language>
         </label>
         <label>
-            <labelName>How many news ?</labelName>
+            <labelName>Anzahl der Nachrichten</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -324,6 +340,10 @@
             <value lang="en">Yes##No</value>
         </parameter>
         <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
+        <parameter>
             <name>default</name>
             <value lang="fr">1</value>
         </parameter>
@@ -366,6 +386,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Yes##No</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -411,6 +435,10 @@
             <name>values</name>
             <value lang="en">Yes##No</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -451,6 +479,10 @@
             <name>values</name>
             <value lang="en">Yes##No</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -486,6 +518,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Yes, about the entire platform##Yes, only on this subspace##No</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja, über die gesamte Plattform##Ja, nur auf diesem Unterraum##Nein</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -699,6 +735,10 @@
             <name>values</name>
             <value lang="en">Open in a new tab</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">In einem neuen Tab öffnen</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -810,6 +850,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Open in a new tab</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">In einem neuen Tab öffnen</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -923,6 +967,10 @@
             <name>values</name>
             <value lang="en">Open in a new tab</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">In einem neuen Tab öffnen</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -1033,7 +1081,11 @@
         </parameter>
         <parameter>
             <name>values</name>
-            <value lang="eb">Open in a new tab</value>
+            <value lang="en">Open in a new tab</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">In einem neuen Tab öffnen</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1142,6 +1194,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Open in a new tab</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">In einem neuen Tab öffnen</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1254,6 +1310,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Open in a new tab</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">In einem neuen Tab öffnen</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1398,6 +1458,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Yes##No</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>

--- a/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/searchresult.xml
+++ b/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/searchresult.xml
@@ -16,7 +16,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Display administrator(s)</labelName>
+            <labelName>Administrator(en) anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -60,7 +60,7 @@
             <language>en</language>
         </label>
          <label>
-            <labelName>Display subspaces navigation</labelName>
+            <labelName>Unterraumnavigation anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -104,7 +104,7 @@
             <language>en</language>
         </label>
          <label>
-            <labelName>Display space applications</labelName>
+            <labelName>Raumanwendungen anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -148,7 +148,7 @@
             <language>en</language>
         </label>
          <label>
-            <labelName>Display the news</labelName>
+            <labelName>Zeigen Sie die Nachrichten an</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -192,7 +192,7 @@
             <language>en</language>
         </label>
          <label>
-            <labelName>Location of the news</labelName>
+            <labelName>Ort der Nachrichten</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -209,7 +209,7 @@
         </parameter>
         <parameter>
             <name>values</name>
-            <value lang="de">Main##Right side</value>
+            <value lang="de">Hauptseite##Rechte Seite</value>
         </parameter>
         <parameter>
             <name>cols</name>
@@ -320,7 +320,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>News from subspaces too</labelName>
+            <labelName>Neuigkeiten auch aus Unterräumen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -368,7 +368,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Important news only</labelName>
+            <labelName>Nur wichtige Neuigkeiten</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -416,7 +416,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Display events</labelName>
+            <labelName>Ereignisse anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -460,7 +460,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Display media</labelName>
+            <labelName>Medien anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -504,7 +504,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Search zone with taxonomy</labelName>
+            <labelName>Suchzone mit Taxonomie</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -544,7 +544,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Lastest Publications, how many ?</labelName>
+            <labelName>Letzte Veröffentlichungen, wie viele?</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -576,7 +576,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Introduction</labelName>
+            <labelName>Vorwort</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -612,7 +612,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>First Picture on the main container</labelName>
+            <labelName>Erstes Bild auf dem Hauptcontainer</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -644,7 +644,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #1 - URL</labelName>
+            <labelName>Abkürzung #1 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -668,7 +668,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #1 - Label</labelName>
+            <labelName>Abkürzung #1 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -692,7 +692,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #1 - Icon</labelName>
+            <labelName>Abkürzung #1 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -720,7 +720,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #1 - Target</labelName>
+            <labelName>Abkürzung #1 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -760,7 +760,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #2 - URL</labelName>
+            <labelName>Abkürzung #2 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -784,7 +784,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #2 - Label</labelName>
+            <labelName>Abkürzung #2 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -808,7 +808,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #2 - Icon</labelName>
+            <labelName>Abkürzung #2 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -836,7 +836,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #2 - Target</labelName>
+            <labelName>Abkürzung #2 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -876,7 +876,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #3 - URL</labelName>
+            <labelName>Abkürzung #3 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -900,7 +900,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #3 - Label</labelName>
+            <labelName>Abkürzung #3 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -924,7 +924,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #3 - Icon</labelName>
+            <labelName>Abkürzung #3 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -952,7 +952,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #3 - Target</labelName>
+            <labelName>Abkürzung #3 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -992,7 +992,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - URL</labelName>
+            <labelName>Abkürzung #4 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1012,11 +1012,11 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - URL</labelName>
+            <labelName>Shortcut #4 - Label</labelName>
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - URL</labelName>
+            <labelName>Abkürzung #4 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1040,7 +1040,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - Icon</labelName>
+            <labelName>Abkürzung #4 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1064,11 +1064,11 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - Icon</labelName>
+            <labelName>Shortcut #4 - Target</labelName>
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - Icon</labelName>
+            <labelName>Abkürzung #4 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1108,7 +1108,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #5 - URL</labelName>
+            <labelName>Abkürzung #5 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1132,7 +1132,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #5 - Label</labelName>
+            <labelName>Abkürzung #5 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1156,7 +1156,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #5 - Icon</labelName>
+            <labelName>Abkürzung #5 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1182,6 +1182,10 @@
         <label>
             <labelName>Shortcut #5 - Target</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Abkürzung #5 - Ziel</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>keys</name>
@@ -1220,7 +1224,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #6 - URL</labelName>
+            <labelName>Abkürzung #6 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1244,7 +1248,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #6 - Label</labelName>
+            <labelName>Abkürzung #6 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1268,7 +1272,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #6 - Icon</labelName>
+            <labelName>Abkürzung #6 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1296,7 +1300,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #6 - Target</labelName>
+            <labelName>Abkürzung #6 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1360,7 +1364,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Users - Label</labelName>
+            <labelName>Benutzer - Bezeichnung</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1384,7 +1388,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Second picture - Right container</labelName>
+            <labelName>Zweites Bild - Rechter Container</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1416,7 +1420,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Second picture - Link url</labelName>
+            <labelName>Zweites Bild - Link-URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1440,7 +1444,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Display new users</labelName>
+            <labelName>Neue Benutzer anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1484,7 +1488,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Free zone Title</labelName>
+            <labelName>Freier Zonentitel</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1508,7 +1512,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Free Content</labelName>
+            <labelName>Kostenlose Inhalte</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1540,7 +1544,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Right free zone title</labelName>
+            <labelName>Rechter Freizonentitel</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1564,7 +1568,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Right free zone content</labelName>
+            <labelName>Rechte Freizoneninhalte</labelName>
             <language>de</language>
         </label>
         <parameter>

--- a/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/update.xml
+++ b/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/update.xml
@@ -32,6 +32,10 @@
             <value lang="en">Yes##No</value>
         </parameter>
         <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
+        <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
         </parameter>
@@ -75,6 +79,10 @@
             <name>values</name>
             <value lang="en">Yes##No</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -115,6 +123,10 @@
             <name>values</name>
             <value lang="en">Yes##No</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -150,6 +162,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Yes##No</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
         </parameter>
         <parameter>
             <name>cols</name>
@@ -241,11 +257,11 @@
         </parameter>
         <parameter>
             <name>values</name>
-            <value lang="en">List##Carrousel</value>
+            <value lang="en">List##Carousel</value>
         </parameter>
         <parameter>
             <name>values</name>
-            <value lang="de">List##Carrousel</value>
+            <value lang="de">Liste##Karussell</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -268,11 +284,11 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>How many news ?</labelName>
+            <labelName>Number of news</labelName>
             <language>en</language>
         </label>
         <label>
-            <labelName>How many news ?</labelName>
+            <labelName>Anzahl der Nachrichten</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -324,6 +340,10 @@
             <value lang="en">Yes##No</value>
         </parameter>
         <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
+        <parameter>
             <name>default</name>
             <value lang="fr">1</value>
         </parameter>
@@ -366,6 +386,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Yes##No</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -411,6 +435,10 @@
             <name>values</name>
             <value lang="en">Yes##No</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -451,6 +479,10 @@
             <name>values</name>
             <value lang="en">Yes##No</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -486,6 +518,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Yes, about the entire platform##Yes, only on this subspace##No</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja, über die gesamte Plattform##Ja, nur auf diesem Unterraum##Nein</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -699,6 +735,10 @@
             <name>values</name>
             <value lang="en">Open in a new tab</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">In einem neuen Tab öffnen</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -810,6 +850,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Open in a new tab</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">In einem neuen Tab öffnen</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -923,6 +967,10 @@
             <name>values</name>
             <value lang="en">Open in a new tab</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">In einem neuen Tab öffnen</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -1035,6 +1083,10 @@
             <name>values</name>
             <value lang="en">Open in a new tab</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">In einem neuen Tab öffnen</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -1142,6 +1194,14 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">In einem neuen Tab öffnen</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1254,6 +1314,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Open in a new tab</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">In einem neuen Tab öffnen</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1398,6 +1462,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Yes##No</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>

--- a/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/update.xml
+++ b/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/update.xml
@@ -11,10 +11,14 @@
             <labelName>Administrateur(s)</labelName>
             <language>fr</language>
         </label>
-        <parameter>
-            <name>cols</name>
-            <value lang="fr">2</value>
-        </parameter>
+        <label>
+            <labelName>Display administrator(s)</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Display administrator(s)</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">1##0</value>
@@ -22,6 +26,14 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
+        </parameter>
+        <parameter>
+            <name>cols</name>
+            <value lang="fr">2</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -39,6 +51,14 @@
             <labelName>Sous espace(s)</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Display subspaces navigation</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>Display subspaces navigation</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -50,6 +70,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -67,6 +91,14 @@
             <labelName>Application(s)</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Display space applications</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>Display space applications</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -78,6 +110,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -95,6 +131,14 @@
             <labelName>Afficher</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Display the news</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>Display the news</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">1##0</value>
@@ -102,6 +146,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <parameter>
             <name>cols</name>
@@ -123,6 +171,14 @@
             <labelName>Emplacement</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Location of the news</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>Location of the news</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">main##right</value>
@@ -130,6 +186,14 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Zone principale##Colonne de droite</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Main##Right side</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Main##Right side</value>
         </parameter>
         <parameter>
             <name>cols</name>
@@ -155,6 +219,14 @@
             <labelName>Présentation</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>News presentation</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>News presentation</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -166,6 +238,14 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Liste##Carrousel</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">List##Carrousel</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">List##Carrousel</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -186,6 +266,14 @@
         <label>
             <labelName>Nombre d'actualité</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>How many news ?</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>How many news ?</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>maxLength</name>
@@ -211,6 +299,14 @@
             <labelName>Prendre en compte les sous-espaces</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>News from subspaces too</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>News from subspaces too</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -222,6 +318,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -243,6 +343,14 @@
             <labelName>Importantes seulement</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Important news only</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Important news only</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -254,6 +362,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -276,8 +388,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Events</labelName>
+            <labelName>Display events</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Display events</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>cols</name>
@@ -290,6 +406,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -308,8 +428,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Medias</labelName>
+            <labelName>Display media</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Display media</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>cols</name>
@@ -322,6 +446,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -340,8 +468,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Taxonomy</labelName>
+            <labelName>Search zone with taxonomy</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Search zone with taxonomy</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>keys</name>
@@ -350,6 +482,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui, sur la plateforme entière##Oui, sur l'espace courant##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes, about the entire platform##Yes, only on this subspace##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -366,6 +502,14 @@
         <label>
             <labelName>Nombre de dernières publications</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Lastest Publications, how many ?</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Lastest Publications, how many ?</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>maxLength</name>
@@ -390,6 +534,14 @@
         <label>
             <labelName>Introduction</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Preface</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Introduction</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -420,8 +572,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Picture</labelName>
+            <labelName>First Picture on the main container</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>First Picture on the main container</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -451,6 +607,10 @@
             <labelName>Shortcut #1 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #1 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -470,6 +630,10 @@
         <label>
             <labelName>Shortcut #1 - Label</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #1 - Label</labelName>
+            <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -491,6 +655,10 @@
             <labelName>Shortcut #1 - Icon</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #1 - Icon</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>galleries</name>
             <value lang="fr">true</value>
@@ -511,6 +679,14 @@
             <labelName>Raccourci #1 - Cible</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Shortcut #1 - Target</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #1 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -518,6 +694,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -539,6 +719,10 @@
             <labelName>Shortcut #2 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #2 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -559,6 +743,10 @@
             <labelName>Shortcut #2 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #2 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -578,6 +766,10 @@
         <label>
             <labelName>Shortcut #2 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #2 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -603,6 +795,10 @@
             <labelName>Shortcut #2 - Target</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #2 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -610,6 +806,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -631,6 +831,10 @@
             <labelName>Shortcut #3 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #3 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -651,6 +855,10 @@
             <labelName>Shortcut #3 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #3 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -670,6 +878,10 @@
         <label>
             <labelName>Shortcut #3 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #3 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -695,6 +907,10 @@
             <labelName>Shortcut #3 - Target</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #3 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -702,6 +918,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -723,6 +943,10 @@
             <labelName>Shortcut #4 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #4 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -743,6 +967,10 @@
             <labelName>Shortcut #4 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #4 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -762,6 +990,10 @@
         <label>
             <labelName>Shortcut #4 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #4 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -787,6 +1019,10 @@
             <labelName>Shortcut #4 - Target</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #4 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -794,6 +1030,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -815,6 +1055,10 @@
             <labelName>Shortcut #5 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #5 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -835,6 +1079,10 @@
             <labelName>Shortcut #5 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #5 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -854,6 +1102,10 @@
         <label>
             <labelName>Shortcut #5 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #5 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -878,6 +1130,10 @@
         <label>
             <labelName>Shortcut #5 - Target</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #5 - Target</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>keys</name>
@@ -907,6 +1163,10 @@
             <labelName>Shortcut #6 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #6 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -927,6 +1187,10 @@
             <labelName>Shortcut #6 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #6 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -946,6 +1210,10 @@
         <label>
             <labelName>Shortcut #6 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #6 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -971,6 +1239,10 @@
             <labelName>Shortcut #6 - Target</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #6 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -978,6 +1250,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -999,6 +1275,10 @@
             <labelName>Users</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Users</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -1019,6 +1299,10 @@
             <labelName>Users - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Users - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -1036,8 +1320,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Second picture</labelName>
+            <labelName>Second picture - Right container</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Second picture - Right container</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -1064,8 +1352,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Second picture - Lien</labelName>
+            <labelName>Second picture - Link url</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Second picture - Link url</labelName>
+            <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1084,8 +1376,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>New users</labelName>
+            <labelName>Display new users</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Display new users</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>cols</name>
@@ -1098,6 +1394,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1112,8 +1412,16 @@
         <isDisabled>false</isDisabled>
         <isHidden>false</isHidden>
         <label>
-            <labelName>Titre</labelName>
+            <labelName>Titre de la zone libre</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Free zone Title</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Free zone Title</labelName>
+            <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1130,6 +1438,14 @@
         <label>
             <labelName>Contenu</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Free Content</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Free Content</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -1155,6 +1471,14 @@
             <labelName>Titre</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Right free zone title</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Right free zone title</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -1170,6 +1494,14 @@
         <label>
             <labelName>Contenu</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Right free zone content</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Right free zone content</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>

--- a/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/update.xml
+++ b/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/update.xml
@@ -16,7 +16,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Display administrator(s)</labelName>
+            <labelName>Administrator(en) anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -60,7 +60,7 @@
             <language>en</language>
         </label>
          <label>
-            <labelName>Display subspaces navigation</labelName>
+            <labelName>Unterraumnavigation anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -104,7 +104,7 @@
             <language>en</language>
         </label>
          <label>
-            <labelName>Display space applications</labelName>
+            <labelName>Raumanwendungen anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -148,7 +148,7 @@
             <language>en</language>
         </label>
          <label>
-            <labelName>Display the news</labelName>
+            <labelName>Zeigen Sie die Nachrichten an</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -192,7 +192,7 @@
             <language>en</language>
         </label>
          <label>
-            <labelName>Location of the news</labelName>
+            <labelName>Ort der Nachrichten</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -209,7 +209,7 @@
         </parameter>
         <parameter>
             <name>values</name>
-            <value lang="de">Main##Right side</value>
+            <value lang="de">Hauptseite##Rechte Seite</value>
         </parameter>
         <parameter>
             <name>cols</name>
@@ -320,7 +320,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>News from subspaces too</labelName>
+            <labelName>Neuigkeiten auch aus Unterräumen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -368,7 +368,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Important news only</labelName>
+            <labelName>Nur wichtige Neuigkeiten</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -416,7 +416,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Display events</labelName>
+            <labelName>Ereignisse anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -460,7 +460,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Display media</labelName>
+            <labelName>Medien anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -504,7 +504,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Search zone with taxonomy</labelName>
+            <labelName>Suchzone mit Taxonomie</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -544,7 +544,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Lastest Publications, how many ?</labelName>
+            <labelName>Letzte Veröffentlichungen, wie viele?</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -576,7 +576,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Introduction</labelName>
+            <labelName>Vorwort</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -612,7 +612,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>First Picture on the main container</labelName>
+            <labelName>Erstes Bild auf dem Hauptcontainer</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -644,7 +644,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #1 - URL</labelName>
+            <labelName>Abkürzung #1 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -668,7 +668,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #1 - Label</labelName>
+            <labelName>Abkürzung #1 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -692,7 +692,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #1 - Icon</labelName>
+            <labelName>Abkürzung #1 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -720,7 +720,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #1 - Target</labelName>
+            <labelName>Abkürzung #1 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -760,7 +760,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #2 - URL</labelName>
+            <labelName>Abkürzung #2 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -784,7 +784,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #2 - Label</labelName>
+            <labelName>Abkürzung #2 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -808,7 +808,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #2 - Icon</labelName>
+            <labelName>Abkürzung #2 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -836,7 +836,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #2 - Target</labelName>
+            <labelName>Abkürzung #2 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -876,7 +876,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #3 - URL</labelName>
+            <labelName>Abkürzung #3 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -900,7 +900,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #3 - Label</labelName>
+            <labelName>Abkürzung #3 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -924,7 +924,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #3 - Icon</labelName>
+            <labelName>Abkürzung #3 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -952,7 +952,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #3 - Target</labelName>
+            <labelName>Abkürzung #3 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -992,7 +992,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - URL</labelName>
+            <labelName>Abkürzung #4 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1016,7 +1016,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - Label</labelName>
+            <labelName>Abkürzung #4 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1040,7 +1040,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - Icon</labelName>
+            <labelName>Abkürzung #4 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1068,7 +1068,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - Target</labelName>
+            <labelName>Abkürzung #4 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1108,7 +1108,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #5 - URL</labelName>
+            <labelName>Abkürzung #5 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1132,7 +1132,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #5 - Label</labelName>
+            <labelName>Abkürzung #5 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1156,7 +1156,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #5 - Icon</labelName>
+            <labelName>Abkürzung #5 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1184,7 +1184,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #5 - Target</labelName>
+            <labelName>Abkürzung #5 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1224,7 +1224,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #6 - URL</labelName>
+            <labelName>Abkürzung #6 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1248,7 +1248,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #6 - Label</labelName>
+            <labelName>Abkürzung #6 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1272,7 +1272,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #6 - Icon</labelName>
+            <labelName>Abkürzung #6 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1300,7 +1300,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #6 - Target</labelName>
+            <labelName>Abkürzung #6 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1364,7 +1364,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Users - Label</labelName>
+            <labelName>Benutzer - Bezeichnung</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1388,7 +1388,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Second picture - Right container</labelName>
+            <labelName>Zweites Bild - Rechter Container</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1420,7 +1420,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Second picture - Link url</labelName>
+            <labelName>Zweites Bild - Link-URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1444,7 +1444,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Display new users</labelName>
+            <labelName>Neue Benutzer anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1488,7 +1488,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Free zone Title</labelName>
+            <labelName>Freier Zonentitel</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1512,7 +1512,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Free Content</labelName>
+            <labelName>Kostenlose Inhalte</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1544,7 +1544,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Right free zone title</labelName>
+            <labelName>Rechter Freizonentitel</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1568,7 +1568,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Right free zone content</labelName>
+            <labelName>Rechte Freizoneninhalte</labelName>
             <language>de</language>
         </label>
         <parameter>

--- a/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/view.xml
+++ b/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/view.xml
@@ -16,7 +16,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Display administrator(s)</labelName>
+            <labelName>Administrator(en) anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -60,7 +60,7 @@
             <language>en</language>
         </label>
          <label>
-            <labelName>Display subspaces navigation</labelName>
+            <labelName>Unterraumnavigation anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -104,7 +104,7 @@
             <language>en</language>
         </label>
          <label>
-            <labelName>Display space applications</labelName>
+            <labelName>Raumanwendungen anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -148,7 +148,7 @@
             <language>en</language>
         </label>
          <label>
-            <labelName>Display the news</labelName>
+            <labelName>Zeigen Sie die Nachrichten an</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -192,7 +192,7 @@
             <language>en</language>
         </label>
          <label>
-            <labelName>Location of the news</labelName>
+            <labelName>Ort der Nachrichten</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -209,7 +209,7 @@
         </parameter>
         <parameter>
             <name>values</name>
-            <value lang="de">Main##Right side</value>
+            <value lang="de">Hauptseite##Rechte Seite</value>
         </parameter>
         <parameter>
             <name>cols</name>
@@ -320,7 +320,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>News from subspaces too</labelName>
+            <labelName>Neuigkeiten auch aus Unterräumen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -368,7 +368,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Important news only</labelName>
+            <labelName>Nur wichtige Neuigkeiten</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -416,7 +416,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Display events</labelName>
+            <labelName>Ereignisse anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -460,7 +460,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Display media</labelName>
+            <labelName>Medien anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -504,7 +504,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Search zone with taxonomy</labelName>
+            <labelName>Suchzone mit Taxonomie</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -544,7 +544,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Lastest Publications, how many ?</labelName>
+            <labelName>Letzte Veröffentlichungen, wie viele?</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -576,7 +576,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Introduction</labelName>
+            <labelName>Vorwort</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -612,7 +612,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>First Picture on the main container</labelName>
+            <labelName>Erstes Bild auf dem Hauptcontainer</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -644,7 +644,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #1 - URL</labelName>
+            <labelName>Abkürzung #1 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -668,7 +668,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #1 - Label</labelName>
+            <labelName>Abkürzung #1 - Label</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -692,7 +692,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #1 - Icon</labelName>
+            <labelName>Abkürzung #1 - Icon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -714,6 +714,14 @@
         <label>
             <labelName>Raccourci #1 - Cible</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Shortcut #1 - Target</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Abkürzung #1 - Ziel</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>keys</name>
@@ -752,7 +760,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #2 - URL</labelName>
+            <labelName>Abkürzung #2 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -776,7 +784,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #2 - Label</labelName>
+            <labelName>Abkürzung #2 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -800,7 +808,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #2 - Icon</labelName>
+            <labelName>Abkürzung #2 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -828,7 +836,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #2 - Target</labelName>
+            <labelName>Abkürzung #2 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -868,7 +876,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #3 - URL</labelName>
+            <labelName>Abkürzung #3 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -892,7 +900,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #3 - Label</labelName>
+            <labelName>Abkürzung #3 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -916,7 +924,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #3 - Icon</labelName>
+            <labelName>Abkürzung #3 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -944,7 +952,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #3 - Target</labelName>
+            <labelName>Abkürzung #3 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -984,7 +992,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - URL</labelName>
+            <labelName>Abkürzung #4 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1008,7 +1016,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - Label</labelName>
+            <labelName>Abkürzung #4 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1032,7 +1040,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - Icon</labelName>
+            <labelName>Abkürzung #4 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1060,7 +1068,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #4 - Target</labelName>
+            <labelName>Abkürzung #4 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1100,7 +1108,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #5 - URL</labelName>
+            <labelName>Abkürzung #5 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1124,7 +1132,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #5 - Label</labelName>
+            <labelName>Abkürzung #5 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1148,7 +1156,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #5 - Icon</labelName>
+            <labelName>Abkürzung #5 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1176,7 +1184,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #5 - Target</labelName>
+            <labelName>Abkürzung #5 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1216,7 +1224,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #6 - URL</labelName>
+            <labelName>Abkürzung #6 - URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1240,7 +1248,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #6 - Label</labelName>
+            <labelName>Abkürzung #6 - Etikett</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1264,7 +1272,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #6 - Icon</labelName>
+            <labelName>Abkürzung #6 - Ikon</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1292,7 +1300,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Shortcut #6 - Target</labelName>
+            <labelName>Abkürzung #6 - Ziel</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1356,7 +1364,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Users - Label</labelName>
+            <labelName>Benutzer - Bezeichnung</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1380,7 +1388,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Second picture - Right container</labelName>
+            <labelName>Zweites Bild - Rechter Container</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1412,7 +1420,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Second picture - Link url</labelName>
+            <labelName>Zweites Bild - Link-URL</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1436,7 +1444,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Display new users</labelName>
+            <labelName>Neue Benutzer anzeigen</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1480,7 +1488,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Free zone Title</labelName>
+            <labelName>Freier Zonentitel</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1504,7 +1512,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Free Content</labelName>
+            <labelName>Kostenlose Inhalte</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -1536,7 +1544,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Right free zone title</labelName>
+            <labelName>Rechter Freizonentitel</labelName>
             <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
@@ -1560,7 +1568,7 @@
             <language>en</language>
         </label>
         <label>
-            <labelName>Right free zone content</labelName>
+            <labelName>Rechte Freizoneninhalte</labelName>
             <language>de</language>
         </label>
         <parameter>

--- a/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/view.xml
+++ b/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/view.xml
@@ -32,6 +32,10 @@
             <value lang="en">Yes##No</value>
         </parameter>
         <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
+        <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
         </parameter>
@@ -75,6 +79,10 @@
             <name>values</name>
             <value lang="en">Yes##No</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -115,6 +123,10 @@
             <name>values</name>
             <value lang="en">Yes##No</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -150,6 +162,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Yes##No</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
         </parameter>
         <parameter>
             <name>cols</name>
@@ -241,11 +257,11 @@
         </parameter>
         <parameter>
             <name>values</name>
-            <value lang="en">List##Carrousel</value>
+            <value lang="en">List##Carousel</value>
         </parameter>
         <parameter>
             <name>values</name>
-            <value lang="de">List##Carrousel</value>
+            <value lang="de">Liste##Karussell</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -268,11 +284,11 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>How many news ?</labelName>
+            <labelName>Number of news</labelName>
             <language>en</language>
         </label>
         <label>
-            <labelName>How many news ?</labelName>
+            <labelName>Anzahl der Nachrichten</labelName>
             <language>de</language>
         </label>
         <parameter>
@@ -324,6 +340,10 @@
             <value lang="en">Yes##No</value>
         </parameter>
         <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
+        <parameter>
             <name>default</name>
             <value lang="fr">1</value>
         </parameter>
@@ -366,6 +386,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Yes##No</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -411,6 +435,10 @@
             <name>values</name>
             <value lang="en">Yes##No</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -451,6 +479,10 @@
             <name>values</name>
             <value lang="en">Yes##No</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -486,6 +518,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Yes, about the entire platform##Yes, only on this subspace##No</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja, über die gesamte Plattform##Ja, nur auf diesem Unterraum##Nein</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -691,6 +727,10 @@
             <name>values</name>
             <value lang="en">Open in a new tab</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">In einem neuen Tab öffnen</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -802,6 +842,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Open in a new tab</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">In einem neuen Tab öffnen</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -917,7 +961,7 @@
         </parameter>
         <parameter>
             <name>values</name>
-            <value lang="de">Open in a new tab</value>
+            <value lang="de">In einem neuen Tab öffnen</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1033,7 +1077,7 @@
         </parameter>
         <parameter>
             <name>values</name>
-            <value lang="de">Open in a new tab</value>
+            <value lang="de">In einem neuen Tab öffnen</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1149,7 +1193,7 @@
         </parameter>
         <parameter>
             <name>values</name>
-            <value lang="de">Open in a new tab</value>
+            <value lang="de">In einem neuen Tab öffnen</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1265,7 +1309,7 @@
         </parameter>
         <parameter>
             <name>values</name>
-            <value lang="de">Open in a new tab</value>
+            <value lang="de">In einem neuen Tab öffnen</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1410,6 +1454,10 @@
         <parameter>
             <name>values</name>
             <value lang="en">Yes##No</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Ja##Nein</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>

--- a/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/view.xml
+++ b/aurora/aurora-configuration/src/main/config/data/templateRepository/auroraspacehomepage/view.xml
@@ -11,10 +11,14 @@
             <labelName>Administrateur(s)</labelName>
             <language>fr</language>
         </label>
-        <parameter>
-            <name>cols</name>
-            <value lang="fr">2</value>
-        </parameter>
+        <label>
+            <labelName>Display administrator(s)</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Display administrator(s)</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">1##0</value>
@@ -22,6 +26,14 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
+        </parameter>
+        <parameter>
+            <name>cols</name>
+            <value lang="fr">2</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -39,6 +51,14 @@
             <labelName>Sous espace(s)</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Display subspaces navigation</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>Display subspaces navigation</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -50,6 +70,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -67,6 +91,14 @@
             <labelName>Application(s)</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Display space applications</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>Display space applications</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -78,6 +110,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -95,6 +131,14 @@
             <labelName>Afficher</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Display the news</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>Display the news</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">1##0</value>
@@ -102,6 +146,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <parameter>
             <name>cols</name>
@@ -123,6 +171,14 @@
             <labelName>Emplacement</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Location of the news</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>Location of the news</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">main##right</value>
@@ -130,6 +186,14 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Zone principale##Colonne de droite</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Main##Right side</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Main##Right side</value>
         </parameter>
         <parameter>
             <name>cols</name>
@@ -155,6 +219,14 @@
             <labelName>Présentation</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>News presentation</labelName>
+            <language>en</language>
+        </label>
+         <label>
+            <labelName>News presentation</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -166,6 +238,14 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Liste##Carrousel</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">List##Carrousel</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">List##Carrousel</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -186,6 +266,14 @@
         <label>
             <labelName>Nombre d'actualité</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>How many news ?</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>How many news ?</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>maxLength</name>
@@ -211,6 +299,14 @@
             <labelName>Prendre en compte les sous-espaces</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>News from subspaces too</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>News from subspaces too</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -222,6 +318,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -243,6 +343,14 @@
             <labelName>Importantes seulement</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Important news only</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Important news only</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>cols</name>
             <value lang="fr">2</value>
@@ -254,6 +362,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <parameter>
             <name>default</name>
@@ -276,8 +388,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Events</labelName>
+            <labelName>Display events</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Display events</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>cols</name>
@@ -290,6 +406,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -308,8 +428,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Medias</labelName>
+            <labelName>Display media</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Display media</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>cols</name>
@@ -322,6 +446,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -340,8 +468,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Taxonomy</labelName>
+            <labelName>Search zone with taxonomy</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Search zone with taxonomy</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>keys</name>
@@ -350,6 +482,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui, sur la plateforme entière##Oui, sur l'espace courant##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes, about the entire platform##Yes, only on this subspace##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -366,6 +502,14 @@
         <label>
             <labelName>Nombre de dernières publications</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Lastest Publications, how many ?</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Lastest Publications, how many ?</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>maxLength</name>
@@ -390,6 +534,14 @@
         <label>
             <labelName>Introduction</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Preface</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Introduction</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -420,8 +572,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Picture</labelName>
+            <labelName>First Picture on the main container</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>First Picture on the main container</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -451,6 +607,10 @@
             <labelName>Shortcut #1 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #1 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -471,6 +631,10 @@
             <labelName>Shortcut #1 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #1 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -490,6 +654,10 @@
         <label>
             <labelName>Shortcut #1 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #1 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -519,6 +687,10 @@
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
         </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
+        </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -538,6 +710,10 @@
         <label>
             <labelName>Shortcut #2 - URL</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #2 - URL</labelName>
+            <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -559,6 +735,10 @@
             <labelName>Shortcut #2 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #2 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -578,6 +758,10 @@
         <label>
             <labelName>Shortcut #2 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #2 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -603,6 +787,10 @@
             <labelName>Shortcut #2 - Target</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #2 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -610,6 +798,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -631,6 +823,10 @@
             <labelName>Shortcut #3 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #3 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -651,6 +847,10 @@
             <labelName>Shortcut #3 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #3 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -670,6 +870,10 @@
         <label>
             <labelName>Shortcut #3 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #3 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -695,6 +899,10 @@
             <labelName>Shortcut #3 - Target</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #3 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -702,6 +910,14 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -723,6 +939,10 @@
             <labelName>Shortcut #4 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #4 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -743,6 +963,10 @@
             <labelName>Shortcut #4 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #4 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -762,6 +986,10 @@
         <label>
             <labelName>Shortcut #4 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #4 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -787,6 +1015,10 @@
             <labelName>Shortcut #4 - Target</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #4 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -794,6 +1026,14 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -815,6 +1055,10 @@
             <labelName>Shortcut #5 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #5 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -835,6 +1079,10 @@
             <labelName>Shortcut #5 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #5 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -854,6 +1102,10 @@
         <label>
             <labelName>Shortcut #5 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #5 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -879,6 +1131,10 @@
             <labelName>Shortcut #5 - Target</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #5 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -886,6 +1142,14 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -907,6 +1171,10 @@
             <labelName>Shortcut #6 - URL</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #6 - URL</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -927,6 +1195,10 @@
             <labelName>Shortcut #6 - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #6 - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -946,6 +1218,10 @@
         <label>
             <labelName>Shortcut #6 - Icon</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Shortcut #6 - Icon</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -971,6 +1247,10 @@
             <labelName>Shortcut #6 - Target</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Shortcut #6 - Target</labelName>
+            <language>de</language>
+        </label>
         <parameter>
             <name>keys</name>
             <value lang="fr">_blank</value>
@@ -978,6 +1258,14 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Nouvelle fenêtre</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Open in a new tab</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="de">Open in a new tab</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -999,6 +1287,10 @@
             <labelName>Users</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Users</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -1019,6 +1311,10 @@
             <labelName>Users - Label</labelName>
             <language>en</language>
         </label>
+        <label>
+            <labelName>Users - Label</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -1036,8 +1332,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Second picture</labelName>
+            <labelName>Second picture - Right container</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Second picture - Right container</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -1064,8 +1364,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>Second picture - Lien</labelName>
+            <labelName>Second picture - Link url</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Second picture - Link url</labelName>
+            <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1084,8 +1388,12 @@
             <language>fr</language>
         </label>
         <label>
-            <labelName>New users</labelName>
+            <labelName>Display new users</labelName>
             <language>en</language>
+        </label>
+        <label>
+            <labelName>Display new users</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>cols</name>
@@ -1098,6 +1406,10 @@
         <parameter>
             <name>values</name>
             <value lang="fr">Oui##Non</value>
+        </parameter>
+        <parameter>
+            <name>values</name>
+            <value lang="en">Yes##No</value>
         </parameter>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1112,8 +1424,16 @@
         <isDisabled>false</isDisabled>
         <isHidden>false</isHidden>
         <label>
-            <labelName>Titre</labelName>
+            <labelName>Titre de la zone libre</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Free zone Title</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Free zone Title</labelName>
+            <language>de</language>
         </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
@@ -1130,6 +1450,14 @@
         <label>
             <labelName>Contenu</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Free Content</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Free Content</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>
@@ -1155,6 +1483,14 @@
             <labelName>Titre</labelName>
             <language>fr</language>
         </label>
+        <label>
+            <labelName>Right free zone title</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Right free zone title</labelName>
+            <language>de</language>
+        </label>
         <isSearchable>false</isSearchable>
         <isFacet>false</isFacet>
         <maximumNumberOfOccurrences>1</maximumNumberOfOccurrences>
@@ -1170,6 +1506,14 @@
         <label>
             <labelName>Contenu</labelName>
             <language>fr</language>
+        </label>
+        <label>
+            <labelName>Right free zone content</labelName>
+            <language>en</language>
+        </label>
+        <label>
+            <labelName>Right free zone content</labelName>
+            <language>de</language>
         </label>
         <parameter>
             <name>galleries</name>


### PR DESCRIPTION
The missing translation had no text by default, so it was empty. It was really blocking for english or deutch users.